### PR TITLE
Improve formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ var buildFuse = (production) => {
     fuse.bundle("vendor")
         .cache(true)
         .target('browser')
-        .instructions(` 
+        .instructions(`
         + whatwg-fetch
         + something-else-u-need
         `)
@@ -136,7 +136,7 @@ var buildFuse = (production) => {
         .target('browser')
 
 
-    // is production build    
+    // is production build
     production ? null : app.watch()
         .cache(false)
         .sourceMaps(true)
@@ -160,7 +160,7 @@ var buildFuse = (production) => {
 
 
 ```typescript
-interface IOptionsInterface {
+interface ITypeCheckerOptionsInterface {
     tsConfig: string; //config file (compared to basepath './tsconfig.json')
     throwOnSyntactic?: boolean; // if you want it to throwe error
     throwOnSemantic?: boolean; // if you want it to throwe error
@@ -176,6 +176,7 @@ interface IOptionsInterface {
     yellowOnGlobal?: boolean; // use yellow color instead of red on Global errors
     yellowOnSemantic?: boolean; // use yellow color instead of red on Semantic errors
     yellowOnSyntactic?: boolean; // use yellow color instead of red on Syntactic errors
+    shortenFilenames?: boolean; // use shortened filenames in order to make output less noisy
 }
 
 

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -169,10 +169,12 @@ export class Checker {
       });
 
       let allErrors = Object.entries(groupedErrors)
-        .map(([fileName, errors]) => {
-            return chalk.red(`└── ${fileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
+        .map(([fullFileName, errors]) => {
+          const short = this.options.shortenFilenames;
+          const shortFileName = fullFileName.split(options.basePath).join('.');
+          return chalk.red(`└── ${shortFileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
             let text = chalk.red('   |');
-            text += chalk[err.color](` (${err.line + 1},${err.char + 1}) `);
+            text += chalk[err.color](` ${short ? shortFileName : fullFileName} (${err.line + 1},${err.char + 1}) `);
             if (isTSError(err)) {
               text += chalk.white(`(${(<ITSError>err).category}:`);
               text += chalk.white(`${(<ITSError>err).code})`);
@@ -319,7 +321,7 @@ export class Checker {
         .map(
           (fileResult: tslint.LintResult) =>
             fileResult.failures.map((failure: any) => ({
-              fileName: failure.fileName.split(options.basePath).join('.'),
+              fileName: failure.fileName,
               line: failure.startPosition.lineAndCharacter.line,
               char: failure.startPosition.lineAndCharacter.character,
               ruleSeverity: failure.ruleSeverity.charAt(0).toUpperCase() + failure.ruleSeverity.slice(1),
@@ -362,7 +364,7 @@ export class Checker {
           character
         } = diag.file.getLineAndCharacterOfPosition(diag.start);
         return {
-          fileName: diag.file.fileName.split(options.basePath).join('.'),
+          fileName: diag.file.fileName,
           line: line + 1, // `(${line + 1},${character + 1})`,
           message: ts.flattenDiagnosticMessageText(diag.messageText, END_LINE),
           char: character + 1,

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -173,7 +173,7 @@ export class Checker {
           const short = this.options.shortenFilenames;
           const fullFileName = path.resolve(fileName);
           const shortFileName = fullFileName.split(options.basePath).join('.');
-          return chalk.red(`└── ${shortFileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
+          return chalk.white(`└── ${shortFileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
             let text = chalk.red('   |');
             text += chalk[err.color](` ${short ? shortFileName : fullFileName} (${err.line + 1},${err.char + 1}) `);
             if (isTSError(err)) {

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -169,8 +169,9 @@ export class Checker {
       });
 
       let allErrors = Object.entries(groupedErrors)
-        .map(([fullFileName, errors]) => {
+        .map(([fileName, errors]) => {
           const short = this.options.shortenFilenames;
+          const fullFileName = path.resolve(fileName);
           const shortFileName = fullFileName.split(options.basePath).join('.');
           return chalk.red(`└── ${shortFileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
             let text = chalk.red('   |');

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -2,27 +2,7 @@ import * as ts from 'typescript';
 import * as chalk from 'chalk';
 import * as tslint from 'tslint';
 import * as path from 'path';
-import { IInternalTypeCheckerOptions, END_LINE } from './interfaces';
-
-interface ITSLintError {
-	fileName: string;
-	line: number;
-	char: number;
-	failure: string;
-	color: string;
-	ruleSeverity: string;
-	ruleName: string;
-}
-
-interface ITSError {
-	fileName: string;
-	line: number;
-	char: number;
-	message: string;
-	color: string;
-	category: string;
-	code: string;
-}
+import { IInternalTypeCheckerOptions, END_LINE, ITSLintError, ITSError } from './interfaces';
 
 type TypeCheckError = ITSLintError | ITSError;
 function isTSError(error: TypeCheckError) {

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -6,7 +6,7 @@ import { IInternalTypeCheckerOptions, END_LINE, ITSLintError, ITSError } from '.
 
 type TypeCheckError = ITSLintError | ITSError;
 function isTSError(error: TypeCheckError) {
-	return (<ITSError>error).code !== undefined;
+  return (<ITSError>error).code !== undefined;
 }
 
 export class Checker {
@@ -150,7 +150,7 @@ export class Checker {
         );
 
         // get the lint errors messages
-      let lintErrorMessages:TypeCheckError[] = this.processLintFiles();
+      let lintErrorMessages: TypeCheckError[] = this.processLintFiles();
 
         // loop diagnostics and get the errors messages
       let tsErrorMessages: TypeCheckError[] = this.processTsDiagnostics();
@@ -158,34 +158,34 @@ export class Checker {
         // combine errors and print if any
       let combinedErrors: TypeCheckError[] = tsErrorMessages.concat(lintErrorMessages);
 
-			// group by filename
-			let groupedErrors: {[k: string]: TypeCheckError[]} = {}
-			combinedErrors.forEach((error: TypeCheckError) => {
-				if (!groupedErrors[error.fileName]) {
-					groupedErrors[error.fileName] = [] as TypeCheckError[]
-				}
+      // group by filename
+      let groupedErrors: {[k: string]: TypeCheckError[]} = {};
+      combinedErrors.forEach((error: TypeCheckError) => {
+        if (!groupedErrors[error.fileName]) {
+          groupedErrors[error.fileName] = [] as TypeCheckError[];
+        }
 
-				groupedErrors[error.fileName].push(error)
-			})
+        groupedErrors[error.fileName].push(error);
+      });
 
-			let allErrors = Object.entries(groupedErrors)
-				.map(([fileName, errors]) => {
-					return chalk.red(`└── ${fileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
-						let text = chalk.red('   |');
-						text += chalk[err.color](` (${err.line + 1},${err.char + 1}) `)
-						if (isTSError(err)) {
-							text += chalk.white(`(${(<ITSError>err).category}:`);
-							text += chalk.white(`${(<ITSError>err).code})`);
-							text += ' ' + (<ITSError>err).message;
-						} else {
-							text += chalk.white(`(${(<ITSLintError>err).ruleSeverity}:`);
-							text += chalk.white(`${(<ITSLintError>err).ruleName})`);
-							text += ' ' + (<ITSLintError>err).failure;
-						}
-						return text;
-					}).join(END_LINE)
-				})
+      let allErrors = Object.entries(groupedErrors)
+        .map(([fileName, errors]) => {
+            return chalk.red(`└── ${fileName}`) + END_LINE + errors.map((err: TypeCheckError) => {
+            let text = chalk.red('   |');
+            text += chalk[err.color](` (${err.line + 1},${err.char + 1}) `);
+            if (isTSError(err)) {
+              text += chalk.white(`(${(<ITSError>err).category}:`);
+              text += chalk.white(`${(<ITSError>err).code})`);
+              text += ' ' + (<ITSError>err).message;
+            } else {
+              text += chalk.white(`(${(<ITSLintError>err).ruleSeverity}:`);
+              text += chalk.white(`${(<ITSLintError>err).ruleName})`);
+              text += ' ' + (<ITSLintError>err).failure;
+            }
 
+            return text;
+          }).join(END_LINE);
+        });
 
         // print if any
         if (allErrors.length > 0) {
@@ -313,21 +313,21 @@ export class Checker {
      */
     private processLintFiles(): ITSLintError[] {
       const options = this.options;
-			const erroredLintFiles = this.lintFileResult
-				.filter((fileResult: tslint.LintResult) => fileResult.failures)
-			const errors = erroredLintFiles
-				.map(
-					(fileResult: tslint.LintResult) =>
-						fileResult.failures.map((failure: any) => ({
-							fileName: failure.fileName.split(options.basePath).join('.'),
-							line: failure.startPosition.lineAndCharacter.line,
-							char: failure.startPosition.lineAndCharacter.character,
-							ruleSeverity: failure.ruleSeverity.charAt(0).toUpperCase() + failure.ruleSeverity.slice(1),
-							ruleName: failure.ruleName,
-							color: options.yellowOnLint ? 'yellow' : 'red',
-							failure: failure.failure
-						}))).reduce((acc, curr) => acc.concat(curr), [])
-			return errors
+      const erroredLintFiles = this.lintFileResult
+        .filter((fileResult: tslint.LintResult) => fileResult.failures);
+      const errors = erroredLintFiles
+        .map(
+          (fileResult: tslint.LintResult) =>
+            fileResult.failures.map((failure: any) => ({
+              fileName: failure.fileName.split(options.basePath).join('.'),
+              line: failure.startPosition.lineAndCharacter.line,
+              char: failure.startPosition.lineAndCharacter.character,
+              ruleSeverity: failure.ruleSeverity.charAt(0).toUpperCase() + failure.ruleSeverity.slice(1),
+              ruleName: failure.ruleName,
+              color: options.yellowOnLint ? 'yellow' : 'red',
+              failure: failure.failure
+            }))).reduce((acc, curr) => acc.concat(curr), []);
+      return errors;
     }
 
     /**
@@ -337,39 +337,39 @@ export class Checker {
   private processTsDiagnostics(): ITSError[] {
     const options = this.options;
     return this.tsDiagnostics
-			.filter((diag: any) => diag.file)
-			.map((diag: any) => {
-				// set color from options
-				let color: string;
-				switch (diag._type) {
-					case 'options':
-						color = options.yellowOnOptions ? 'yellow' : 'red';
-						break;
-					case 'global':
-						color = options.yellowOnGlobal ? 'yellow' : 'red';
-						break;
-					case 'syntactic':
-						color = options.yellowOnSyntactic ? 'yellow' : 'red';
-						break;
-					case 'semantic':
-						color = options.yellowOnSemantic ? 'yellow' : 'red';
-						break;
-					default:
-						color = 'red';
-				}
-				const {
-					line,
-					character
-				} = diag.file.getLineAndCharacterOfPosition(diag.start);
-				return {
-					fileName: diag.file.fileName.split(options.basePath).join('.'),
-					line: line + 1, // `(${line + 1},${character + 1})`,
-					message: ts.flattenDiagnosticMessageText(diag.messageText, END_LINE),
-					char: character + 1,
-					color: color,
-					category: `${ts.DiagnosticCategory[diag.category]}:`,
-					code: `TS${diag.code}`
-				}
-			});
-	}
+      .filter((diag: any) => diag.file)
+      .map((diag: any) => {
+        // set color from options
+        let color: string;
+        switch (diag._type) {
+          case 'options':
+            color = options.yellowOnOptions ? 'yellow' : 'red';
+            break;
+          case 'global':
+            color = options.yellowOnGlobal ? 'yellow' : 'red';
+            break;
+          case 'syntactic':
+            color = options.yellowOnSyntactic ? 'yellow' : 'red';
+            break;
+          case 'semantic':
+            color = options.yellowOnSemantic ? 'yellow' : 'red';
+            break;
+          default:
+            color = 'red';
+        }
+        const {
+          line,
+          character
+        } = diag.file.getLineAndCharacterOfPosition(diag.start);
+        return {
+          fileName: diag.file.fileName.split(options.basePath).join('.'),
+          line: line + 1, // `(${line + 1},${character + 1})`,
+          message: ts.flattenDiagnosticMessageText(diag.messageText, END_LINE),
+          char: character + 1,
+          color: color,
+          category: `${ts.DiagnosticCategory[diag.category]}:`,
+          code: `TS${diag.code}`
+        };
+      });
+    }
 }

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -209,12 +209,10 @@ export class Checker {
 
         // print if any
         if (allErrors.length > 0) {
-
             // insert header
-            // allErrors.unshift(
-            //     chalk.underline(`${END_LINE}File errors`) + chalk.white(':') // fix windows
-            // );
-
+            allErrors.unshift(
+                chalk.underline(`${END_LINE}File errors`) + chalk.white(':') // fix windows
+            );
             print(allErrors.join(END_LINE));
         }
 
@@ -334,7 +332,7 @@ export class Checker {
      *
      */
     private processLintFiles(): ITSLintError[] {
-        const options = this.options;
+      const options = this.options;
 			const erroredLintFiles = this.lintFileResult
 				.filter((fileResult: tslint.LintResult) => fileResult.failures)
 			const errors = erroredLintFiles
@@ -342,47 +340,47 @@ export class Checker {
 					(fileResult: tslint.LintResult) =>
 						fileResult.failures.map((failure: any) => ({
 							fileName: failure.fileName.split(options.basePath).join('.'),
-                            line: failure.startPosition.lineAndCharacter.line,
-                            char: failure.startPosition.lineAndCharacter.character,
-                            ruleSeverity: failure.ruleSeverity.charAt(0).toUpperCase() + failure.ruleSeverity.slice(1),
-                            ruleName: failure.ruleName,
+							line: failure.startPosition.lineAndCharacter.line,
+							char: failure.startPosition.lineAndCharacter.character,
+							ruleSeverity: failure.ruleSeverity.charAt(0).toUpperCase() + failure.ruleSeverity.slice(1),
+							ruleName: failure.ruleName,
 							color: options.yellowOnLint ? 'yellow' : 'red',
-                            failure: failure.failure
+							failure: failure.failure
 						}))).reduce((acc, curr) => acc.concat(curr), [])
 			return errors
-        }
+    }
 
     /**
      * loops ts failures and return pretty failure string ready to be printed
      *
      */
   private processTsDiagnostics(): ITSError[] {
-        const options = this.options;
+    const options = this.options;
     return this.tsDiagnostics
 			.filter((diag: any) => diag.file)
 			.map((diag: any) => {
-                // set color from options
-                let color: string;
-                switch (diag._type) {
-                    case 'options':
-                        color = options.yellowOnOptions ? 'yellow' : 'red';
-                        break;
-                    case 'global':
-                        color = options.yellowOnGlobal ? 'yellow' : 'red';
-                        break;
-                    case 'syntactic':
-                        color = options.yellowOnSyntactic ? 'yellow' : 'red';
-                        break;
-                    case 'semantic':
-                        color = options.yellowOnSemantic ? 'yellow' : 'red';
-                        break;
-                    default:
-                        color = 'red';
-                }
-                    const {
-                        line,
-                        character
-                    } = diag.file.getLineAndCharacterOfPosition(diag.start);
+				// set color from options
+				let color: string;
+				switch (diag._type) {
+					case 'options':
+						color = options.yellowOnOptions ? 'yellow' : 'red';
+						break;
+					case 'global':
+						color = options.yellowOnGlobal ? 'yellow' : 'red';
+						break;
+					case 'syntactic':
+						color = options.yellowOnSyntactic ? 'yellow' : 'red';
+						break;
+					case 'semantic':
+						color = options.yellowOnSemantic ? 'yellow' : 'red';
+						break;
+					default:
+						color = 'red';
+				}
+				const {
+					line,
+					character
+				} = diag.file.getLineAndCharacterOfPosition(diag.start);
 				return {
 					fileName: diag.file.fileName.split(options.basePath).join('.'),
 					line: line + 1, // `(${line + 1},${character + 1})`,
@@ -391,7 +389,7 @@ export class Checker {
 					color: color,
 					category: `${ts.DiagnosticCategory[diag.category]}:`,
 					code: `TS${diag.code}`
-                }
-            });
-        }
+				}
+			});
+	}
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,9 @@ export class TypeHelperClass {
         // get name
         this.options.name = this.options.name ? ':' + this.options.name : '';
 
+        // shorten filenames to de-clutter output?
+        this.options.shortenFilenames = !!this.options.shortenFilenames;
+
         // tslint options
         let lintOp = this.options.lintoptions;
         this.options.lintoptions = lintOp ? lintOp : ({} as ILintOptions);
@@ -299,4 +302,3 @@ export class TypeHelperClass {
 export const TypeHelper = (options: ITypeCheckerOptions): TypeHelperClass => {
     return new TypeHelperClass(options);
 };
-

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -30,6 +30,9 @@ export interface ITypeCheckerOptions {
     // lint options that can be passed in
     // todo: rename to lintOptions, but thats a breaking change, so will do that later
     lintoptions?: ILintOptions;
+
+    // use shortened filenames in order to make output less cluttered
+    shortenFilenames?: boolean;
 }
 
 // lint options,this is the same as tsLint uses all paths will be from basepath

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,4 +69,24 @@ export enum TypecheckerRunType {
     promiseSync = 'promisesync'  as any
 }
 
+export interface ITSLintError {
+    fileName: string;
+    line: number;
+    char: number;
+    failure: string;
+    color: string;
+    ruleSeverity: string;
+    ruleName: string;
+}
+
+export interface ITSError {
+    fileName: string;
+    line: number;
+    char: number;
+    message: string;
+    color: string;
+    category: string;
+    code: string;
+}
+
 export const END_LINE = '\n';


### PR DESCRIPTION
Improve output formatting so that it is much easier to read.

* Shortened path names to only the current project
  * Long path names made lines wrap so that errors were difficult to follow
* Group Errors by filename
  * Lint errors and type errors were reported in different parts of the output making it difficult to see all errors in one file; they are now next to each other.
  * Because errors are now grouped, we only have to show the filename once, making output less noisy, and giving more room on each line for errors, making them even less likely to wrap.

(The example formatting in the commit message seems broken. I'd suggest viewing the real output by making a few errors in a few files and comparing this output to the current output.)