### PR TITLE
fix missing types entry in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "license": "MIT",
   "author": "Fusebox Community",
   "main": "dist/commonjs/index.js",
+  "types": "dist/commonjs/index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/fuse-box/fuse-box-typechecker"


### PR DESCRIPTION
`types` entry is missing in `package.json` resulting in unresolved types when importing this library.

**Before commit**: 
![image](https://user-images.githubusercontent.com/3646758/33039171-1bb55db0-ce05-11e7-9825-c422d22410cb.png)

**After commit**: 
![image](https://user-images.githubusercontent.com/3646758/33039137-020de256-ce05-11e7-91d4-38d35c0f5ab6.png)
